### PR TITLE
Fix typo in filename automatically generated by running $ rundoc build

### DIFF
--- a/lib/rundoc/cli.rb
+++ b/lib/rundoc/cli.rb
@@ -65,7 +65,7 @@ module Rundoc
       File.open(source_path, "w") { |f| f.write @output }
 
       puts "== Copying source"
-      source_path = project_dir.join("coppied-#{@path.to_s.split('/').last}")
+      source_path = project_dir.join("copied-#{@path.to_s.split('/').last}")
       File.open(source_path, "w") { |f| f.write source_contents }
 
       Dir.chdir(project_dir) do


### PR DESCRIPTION
Hi, I learned your gem from your book [How to Open Source](https://howtoopensource.dev/) and wanted to try it.

After making `run_doc.md` on my project root and running the command `$ rundoc build run_doc.md`, I realized a name of the file generated might be a typo, so I corrected the code that seems relevant😄