### PR TITLE
Refactor env[:before] to hold an array

### DIFF
--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -2,6 +2,18 @@ module Rundoc
   # Generic CodeCommand class to be inherited
   #
   class CodeCommand
+
+    # Newlines are stripped and re-added, this tells the project that
+    # we're intentionally wanting an extra newline
+    NEWLINE = Object.new
+    def NEWLINE.to_s
+      ""
+    end
+
+    def NEWLINE.empty?
+      false
+    end
+
     attr_accessor :render_result, :render_command,
       :command, :contents, :keyword,
       :original_args

--- a/lib/rundoc/code_command/file_command/append.rb
+++ b/lib/rundoc/code_command/file_command/append.rb
@@ -13,12 +13,13 @@ class Rundoc::CodeCommand::FileCommand
       return unless render_command?
 
       raise "must call write in its own code section" unless env[:commands].empty?
-      before = env[:before]
-      env[:before] = if @line_number
-        "In file `#{filename}`, on line #{@line_number} add:\n\n#{before}"
+
+      env[:before] << if @line_number
+        "In file `#{filename}`, on line #{@line_number} add:"
       else
-        "At the end of `#{filename}` add:\n\n#{before}"
+        "At the end of `#{filename}` add:"
       end
+      env[:before] << NEWLINE
       nil
     end
 

--- a/lib/rundoc/code_command/file_command/remove.rb
+++ b/lib/rundoc/code_command/file_command/remove.rb
@@ -8,8 +8,8 @@ class Rundoc::CodeCommand::FileCommand
 
     def to_md(env)
       raise "must call write in its own code section" unless env[:commands].empty?
-      before = env[:before]
-      env[:before] = "In file `#{filename}` remove:\n\n#{before}"
+      env[:before] << "In file `#{filename}` remove:"
+      env[:before] << NEWLINE
       nil
     end
 

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -24,8 +24,8 @@ module Rundoc
 
       def to_md(env)
         raise "must call write in its own code section" unless env[:commands].empty?
-        before = env[:before]
-        env[:before] = "In file `#{filename}` write:\n\n#{before}"
+        env[:before] << "In file `#{filename}` write:"
+        env[:before] << NEWLINE
         nil
       end
 

--- a/lib/rundoc/code_section.rb
+++ b/lib/rundoc/code_section.rb
@@ -44,8 +44,10 @@ module Rundoc
       result = []
       env = {}
       env[:commands] = []
-      env[:before] = +"#{fence}#{lang}"
-      env[:after] = +"#{fence}#{AUTOGEN_WARNING}"
+      env[:fence_start] = +"#{fence}#{lang}"
+      env[:fence_end] = "#{fence}#{AUTOGEN_WARNING}"
+      env[:before] = []
+      env[:after] = []
       env[:document_path] = @document_path
 
       @stack.each do |s|
@@ -71,11 +73,12 @@ module Rundoc
 
       return "" if hidden?
 
-      array = [env[:before], result, env[:after]]
+      array = [env[:before], env[:fence_start], result, env[:fence_end], env[:after]]
       array.flatten!
       array.compact!
-      array.map!(&:rstrip)
+      array.map! {|s| s.respond_to?(:rstrip) ? s.rstrip : s }
       array.reject!(&:empty?)
+      array.map!(&:to_s)
 
       array.join("\n") << "\n"
     end

--- a/test/rundoc/code_commands/remove_contents_test.rb
+++ b/test/rundoc/code_commands/remove_contents_test.rb
@@ -29,10 +29,11 @@ class RemoveContentsTest < Minitest::Test
 
         env = {}
         env[:commands] = []
-        env[:before] = "```ruby"
+        env[:before] = []
+        env[:fence_start] = "```ruby"
         cc.to_md(env)
 
-        assert_equal "In file `foo.rb` remove:\n\n```ruby", env[:before]
+        assert_equal ["In file `foo.rb` remove:", Rundoc::CodeCommand::NEWLINE], env[:before]
       end
     end
   end

--- a/test/rundoc/code_section_test.rb
+++ b/test/rundoc/code_section_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class CodeSectionTest < Minitest::Test
-  def setup
-  end
 
   def test_does_not_render_if_all_contents_hidden
     contents = <<~RUBY


### PR DESCRIPTION
The env[:before] interface allows commands to annotate outside of the code block. Previously this was a string that also contained the code fence information. This work splits the information into a new keys `:fence_start` and `:fence_end` and allows information to be appended directly to env[:before] instead of having to manually insert the prior before value.