### PR TITLE
make newline optional at the end of code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Bugfix: Code blocks without a following newline are now being recognized and executed (https://github.com/zombocom/rundoc/pull/51)
+
 ## 2.0.0
 
 - Change: Ruby 2.7 and 3.0 are no longer supported

--- a/lib/rundoc/parser.rb
+++ b/lib/rundoc/parser.rb
@@ -2,7 +2,7 @@ module Rundoc
   class Parser
     DEFAULT_KEYWORD = ":::"
     INDENT_BLOCK = '(?<before_indent>(^\s*$\n|\A)(^(?:[ ]{4}|\t))(?<indent_contents>.*)(?<after_indent>[^\s].*$\n?(?:(?:^\s*$\n?)*^(?:[ ]{4}|\t).*[^\s].*$\n?)*))'
-    GITHUB_BLOCK = '^(?<fence>(?<fence_char>~|`){3,})\s*?(?<lang>\w+)?\s*?\n(?<contents>.*?)^\g<fence>\g<fence_char>*\s*?\n'
+    GITHUB_BLOCK = '^(?<fence>(?<fence_char>~|`){3,})\s*?(?<lang>\w+)?\s*?\n(?<contents>.*?)^\g<fence>\g<fence_char>*\s*?\n?'
     CODEBLOCK_REGEX = /(#{GITHUB_BLOCK})/m
     COMMAND_REGEX = ->(keyword) {
       /^#{keyword}(?<tag>(\s|=|-|>)?(=|-|>)?)\s*(?<command>(\S)+)\s+(?<statement>.*)$/

--- a/test/rundoc/regex_test.rb
+++ b/test/rundoc/regex_test.rb
@@ -190,4 +190,26 @@ class RegexTest < Minitest::Test
 
     assert_equal contents.strip, match.to_s.strip
   end
+
+  def test_codeblock_optional_newline_regex
+    code_block_with_newline = <<~MD
+      hi
+      ```
+      :::>> $ echo "hello"
+      ```
+    MD
+    code_block_without_newline = code_block_with_newline.strip
+
+    expected = <<~MD.strip
+      ```
+      :::>> $ echo "hello"
+      ```
+    MD
+    regex = Rundoc::Parser::CODEBLOCK_REGEX
+    match = code_block_with_newline.match(regex)
+    assert_equal expected, match.to_s.strip
+
+    match = code_block_without_newline.match(regex)
+    assert_equal expected, match.to_s.strip
+  end
 end


### PR DESCRIPTION
This PR resolves #50 where code blocks in the output markdown file are not executed if there is no newline after the code block in the source file. The output markdown file would then result in having the original text rather than the intended output command execution and its output. 

### Fix Description
The fix modifies the code block detection logic in rundoc to ensure it correctly handles code blocks that do not have a newline character following them. This ensures that all code blocks are executed and their outputs are properly embedded in the generated markdown file. 

### Testing
- Added a unit test to ensure that code blocks without a trailing newline are parsed in the same manner as those that do
- Previous unit tests with code blocks that do have trailing newlines are still passing