### PR TITLE
Write to failed dir on SIGTERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Fix: Save in-progress work in the "failure" directory when the rundoc command is interrupted via a signal such as `SIGTERM` (https://github.com/zombocom/rundoc/pull/67)
+
 ## 3.0.0
 
 - Change: Default directories are now `rundoc_output` (instead of `project`) and `rundoc_failure` (instead of `tmp`).

--- a/lib/rundoc/cli.rb
+++ b/lib/rundoc/cli.rb
@@ -151,7 +151,8 @@ module Rundoc
         )
         output = begin
           parser.to_md
-        rescue => e
+        rescue StandardError, SignalException => e
+          warn "Received exception: #{e.inspect}, cleaning up before re-raise"
           on_fail
           raise e
         end


### PR DESCRIPTION
Calls the `on_fail` logic when a signal is raised https://ruby-doc.org/3.3.6/SignalException.html.

Close #66