### PR TITLE
Include all code blocks in event of failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Fix: Include all code sections in the event of a failure, not just the last one (https://github.com/zombocom/rundoc/pull/71)
+
 ## 3.0.2
 
 - Fix: Partial output of the document is now written to disk in a `RUNDOC_FAILED.md` file (https://github.com/zombocom/rundoc/pull/69)

--- a/lib/rundoc/cli.rb
+++ b/lib/rundoc/cli.rb
@@ -191,7 +191,7 @@ module Rundoc
         to: on_failure_dir
       )
 
-      on_failure_dir.join("RUNDOC_FAILED.md").write(Rundoc::CodeSection.partial_result_to_doc)
+      on_failure_dir.join("RUNDOC_FAILED.md").write(Rundoc::Parser.partial_result_to_doc)
     end
 
     private def on_success(output)

--- a/lib/rundoc/code_section.rb
+++ b/lib/rundoc/code_section.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module Rundoc
-  # holds code, parses and creates CodeCommand
+  # A code secttion respesents a block of fenced code
+  #
+  # A document can have multiple code sections
   class CodeSection
     class ParseError < StandardError
       def initialize(options = {})

--- a/lib/rundoc/parser.rb
+++ b/lib/rundoc/parser.rb
@@ -1,4 +1,8 @@
 module Rundoc
+  # This poorly named class is responsible for taking in the raw markdown and running it
+  #
+  # It works by pulling out the code blocks (CodeSection), and putting them onto a stack.
+  # It then executes each in turn and records the results.
   class Parser
     DEFAULT_KEYWORD = ":::"
     INDENT_BLOCK = '(?<before_indent>(^\s*$\n|\A)(^(?:[ ]{4}|\t))(?<indent_contents>.*)(?<after_indent>[^\s].*$\n?(?:(?:^\s*$\n?)*^(?:[ ]{4}|\t).*[^\s].*$\n?)*))'

--- a/test/integration/failure_test.rb
+++ b/test/integration/failure_test.rb
@@ -1,7 +1,58 @@
 require "test_helper"
 
 class IntegrationFailureTest < Minitest::Test
-  def test_writes_to_dir_on_failure
+  def test_writes_to_dir_on_failure_two_block
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+
+        source_path = dir.join("RUNDOC.md")
+        source_path.write <<~EOF
+          ```
+          :::>> $ mkdir one
+          :::>> $ touch one/rofl.txt
+          ```
+
+          ```
+          :::>> $ mkdir two
+          :::>> $ touch two/rofl.txt
+          :::>> $ touch does/not/exist.txt
+          ```
+        EOF
+
+        io = StringIO.new
+
+        error = nil
+        begin
+          Rundoc::CLI.new(
+            io: io,
+            source_path: source_path,
+            on_success_dir: dir.join(SUCCESS_DIRNAME)
+          ).call
+        rescue => e
+          error = e
+        end
+
+        assert error
+        assert_includes error.message, "exited with non zero status"
+
+        refute dir.join(SUCCESS_DIRNAME).join("two").exist?
+        refute dir.join(SUCCESS_DIRNAME).join("two").join("rofl.txt").exist?
+
+        assert dir.join(FAILURE_DIRNAME).join("two").exist?
+        assert dir.join(FAILURE_DIRNAME).join("two").join("rofl.txt").exist?
+
+        doc = dir.join(FAILURE_DIRNAME).join("RUNDOC_FAILED.md").read
+        assert_includes doc, "$ mkdir one"
+        assert_includes doc, "$ touch one/rofl.txt"
+
+        assert_includes doc, "$ mkdir two"
+        assert_includes doc, "$ touch two/rofl.txt"
+      end
+    end
+  end
+
+  def test_writes_to_dir_on_failure_one_block
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
         dir = Pathname(dir)


### PR DESCRIPTION
The prior PR #69 mistakenly only preserved the last command to be executed instead of the document up to that point. This commit fixes the tests by introducing partial result storage and retrieval to the class that builds and calls the individual CodeSections.