### PR TITLE
Expand `with_contents_dir` to absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Fix: `rundoc <file> --with-contents <dir>` now expands the path passed in to the `--with-contents` so relative paths can safely be used (https://github.com/zombocom/rundoc/pull/83)
+
 ## 3.1.1
 
 - Fix: Include all code sections in the event of a failure, not just the last one (https://github.com/zombocom/rundoc/pull/71)

--- a/lib/rundoc/cli_argument_parser.rb
+++ b/lib/rundoc/cli_argument_parser.rb
@@ -111,7 +111,7 @@ module Rundoc
         end
 
         opts.on("--with-contents <dir>", "Copies contents of directory into the tmp working dir") do |v|
-          options[:with_contents_dir] = v
+          options[:with_contents_dir] = File.expand_path(v)
         end
 
         opts.on("--on-success-dir <dir>", "Success dir, relative to CWD. i.e. `<rundoc.md/dir>/#{CLI::DEFAULTS::ON_SUCCESS_DIR}/`.") do |v|


### PR DESCRIPTION
Previously if you tried using `--with-contents .` you would not get expected behavior.

Close #81