### PR TITLE
Fix relative require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Fix: Using `rundoc.require` inside of a document that was `rundoc.require`-d now sources files from the correct relative document path (https://github.com/zombocom/rundoc/pull/84)
 - Fix: `rundoc <file> --with-contents <dir>` now expands the path passed in to the `--with-contents` so relative paths can safely be used (https://github.com/zombocom/rundoc/pull/83)
 
 ## 3.1.1

--- a/lib/rundoc/code_command/rundoc/require.rb
+++ b/lib/rundoc/code_command/rundoc/require.rb
@@ -14,12 +14,17 @@ class ::Rundoc::CodeCommand
       end
 
       def call(env = {})
-        document_path = @path.expand_path(env[:context].source_dir)
+        execution_context = env[:context]
+        document_path = @path.expand_path(execution_context.source_dir)
 
-        puts "rundoc.require: Start executing #{@path.to_s.inspect}"
         output = Rundoc::Parser.new(
           document_path.read,
-          context: env[:context]
+          context: Rundoc::Context::Execution.new(
+            source_path: document_path,
+            output_dir: execution_context.output_dir,
+            screenshots_dirname: execution_context.screenshots_dir,
+            with_contents_dir: execution_context.with_contents_dir
+          )
         ).to_md
 
         if render_result?


### PR DESCRIPTION
Requiring from one file to another works, requiring one file that requires another doesn't. This change fixes that.

The problem was the execution context was being threaded through unchanged, instead it should have been modifying the source path to reflect that a different document was being executed.

Close #80