### PR TITLE
Fix `pre.erb` visibility forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Fix: Visibility forwarding for `pre.erb` was accidentally reversed, this is now fixed. (https://github.com/zombocom/rundoc/pull/93)
+
 ## 4.1.0
 
 - Add: Rundoc command `pre.erb` command used for dynamically templating any command using ERB syntax. (https://github.com/zombocom/rundoc/pull/90)

--- a/lib/rundoc/code_command/pre/erb.rb
+++ b/lib/rundoc/code_command/pre/erb.rb
@@ -27,8 +27,8 @@ class Rundoc::CodeCommand
     def code
       @code ||= begin
         vis = +""
-        vis += @render_delegate_result ? ">" : "-"
         vis += @render_delegate_command ? ">" : "-"
+        vis += @render_delegate_result ? ">" : "-"
         code = [@line, @contents]
           .compact
           .reject(&:empty?)

--- a/test/integration/pre_erb_test.rb
+++ b/test/integration/pre_erb_test.rb
@@ -1,6 +1,50 @@
 require "test_helper"
 
 class IntegrationPreErb < Minitest::Test
+  def test_result_visibility_forwarding
+    contents = <<~RUBY
+      ```
+      :::-> pre.erb $ echo <%= 1 + 1 %>
+      ```
+    RUBY
+
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        expected = <<~EOF
+          ```
+          2
+          ```
+        EOF
+
+        parsed = parse_contents(contents)
+        actual = parsed.to_md.gsub(Rundoc::FencedCodeBlock::AUTOGEN_WARNING, "").strip
+        assert_equal expected.strip, actual.strip
+      end
+    end
+  end
+
+  def test_command_visibility_forwarding
+    contents = <<~RUBY
+      ```
+      :::>- pre.erb $ echo <%= 1 + 1 %>
+      ```
+    RUBY
+
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        expected = <<~EOF
+          ```
+          $ echo 2
+          ```
+        EOF
+
+        parsed = parse_contents(contents)
+        actual = parsed.to_md.gsub(Rundoc::FencedCodeBlock::AUTOGEN_WARNING, "").strip
+        assert_equal expected.strip, actual.strip
+      end
+    end
+  end
+
   def test_file_write
     key = SecureRandom.hex
     contents = <<~RUBY


### PR DESCRIPTION
I accidentally swapped the order of the visibility markers. This commit fixes that problem and adds tests against future regressions.