### PR TITLE
Fix Background::Wait and exercise in test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Fix: Internal error in `background.wait` introduced in 4.1.2 (https://github.com/zombocom/rundoc/pull/97)
+
 ## 4.1.2
 
 - Fix: Background task name lookup is now lazy, this fixes a bug when using `:::>- pre.erb background.start(...)` (https://github.com/zombocom/rundoc/pull/95)

--- a/lib/rundoc/code_command/background/wait.rb
+++ b/lib/rundoc/code_command/background/wait.rb
@@ -8,7 +8,7 @@ class Rundoc::CodeCommand::Background
     end
 
     def background
-      @background ||= Rundoc::CodeCommand::Background::ProcessSpawn.find(name)
+      @background ||= Rundoc::CodeCommand::Background::ProcessSpawn.find(@name)
     end
 
     def to_md(env = {})

--- a/test/rundoc/code_commands/background_test.rb
+++ b/test/rundoc/code_commands/background_test.rb
@@ -19,6 +19,11 @@ class BackgroundTest < Minitest::Test
         output = stdin_write.call
         assert_equal("hello there" + $/, output)
 
+        Rundoc::CodeCommand::Background::Wait.new(
+          name: "cat",
+          wait: "hello"
+        ).call
+
         Rundoc::CodeCommand::Background::Log::Clear.new(
           name: "cat"
         ).call


### PR DESCRIPTION
I accidentally used `name` instead of `@name` and apparently this functionality is not called under test. So I added tests.

Before:

```
87 runs, 251 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Integration Tests to /Users/rschneeman/Documents/projects/rundoc/coverage.
Line Coverage: 95.32% (1998 / 2096)
```

After:

```
87 runs, 251 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Integration Tests to /Users/rschneeman/Documents/projects/rundoc/coverage.
Line Coverage: 95.66% (2006 / 2097)
```