### PR TITLE
Fix: Website commands now use lazy lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD
 
 - Fix: Internal error in `background.wait` introduced in 4.1.2 (https://github.com/zombocom/rundoc/pull/97)
+- Fix: Website commands such as `:::>> website.visit(...)` now use lazy lookup (like Background tasks since 4.1.2). This allows `pre.erb` to be used with these commands (https://github.com/zombocom/rundoc/pull/98)
 
 ## 4.1.2
 

--- a/lib/rundoc/code_command/website/navigate.rb
+++ b/lib/rundoc/code_command/website/navigate.rb
@@ -2,7 +2,11 @@ class Rundoc::CodeCommand::Website
   class Navigate < Rundoc::CodeCommand
     def initialize(name:)
       @name = name
-      @driver = Rundoc::CodeCommand::Website::Driver.find(name)
+      @driver = nil
+    end
+
+    def driver
+      @driver ||= Rundoc::CodeCommand::Website::Driver.find(@name)
     end
 
     def to_md(env = {})
@@ -11,7 +15,7 @@ class Rundoc::CodeCommand::Website
 
     def call(env = {})
       puts "website.navigate [#{@name}]: #{contents}"
-      @driver.safe_eval(contents, env)
+      driver.safe_eval(contents, env)
       ""
     end
 

--- a/lib/rundoc/code_command/website/screenshot.rb
+++ b/lib/rundoc/code_command/website/screenshot.rb
@@ -1,8 +1,13 @@
 class Rundoc::CodeCommand::Website
   class Screenshot < Rundoc::CodeCommand
     def initialize(name:, upload: false)
-      @driver = Rundoc::CodeCommand::Website::Driver.find(name)
+      @name = name
       @upload = upload
+      @driver = nil
+    end
+
+    def driver
+      @driver ||= Rundoc::CodeCommand::Website::Driver.find(@name)
     end
 
     def to_md(env = {})
@@ -10,14 +15,14 @@ class Rundoc::CodeCommand::Website
     end
 
     def call(env = {})
-      puts "Taking screenshot: #{@driver.current_url}"
-      filename = @driver.screenshot(
+      puts "Taking screenshot: #{driver.current_url}"
+      filename = driver.screenshot(
         upload: @upload,
         screenshots_dir: env[:context].screenshots_dir
       )
 
       relative_filename = filename.relative_path_from(env[:context].output_dir)
-      env[:before] << "![Screenshot of #{@driver.current_url}](#{relative_filename})"
+      env[:before] << "![Screenshot of #{driver.current_url}](#{relative_filename})"
       ""
     end
 

--- a/lib/rundoc/code_command/website/visit.rb
+++ b/lib/rundoc/code_command/website/visit.rb
@@ -6,14 +6,21 @@ class Rundoc::CodeCommand::Website
       @name = name
       @url = url
       @scroll = scroll
-      @driver = Driver.new(
-        name: name,
-        url: url,
-        height: height,
-        width: width,
-        visible: visible
-      )
-      Driver.add(@name, @driver)
+      @height = height
+      @width = width
+      @visible = visible
+    end
+
+    def driver
+      @driver ||= Driver.new(
+        name: @name,
+        url: @url,
+        height: @height,
+        width: @width,
+        visible: @visible
+      ).tap do |driver|
+        Driver.add(@name, driver)
+      end
     end
 
     def to_md(env = {})
@@ -26,11 +33,11 @@ class Rundoc::CodeCommand::Website
 
       puts message
 
-      @driver.visit(@url) if @url
-      @driver.scroll(@scroll) if @scroll
+      driver.visit(@url) if @url
+      driver.scroll(@scroll) if @scroll
 
       return "" if contents.nil? || contents.empty?
-      @driver.safe_eval(contents, env)
+      driver.safe_eval(contents, env)
 
       ""
     end

--- a/test/integration/website_test.rb
+++ b/test/integration/website_test.rb
@@ -6,6 +6,8 @@ class IntegrationWebsiteTest < Minitest::Test
       ```
       :::>> website.visit(name: "example", url: "http://example.com")
       :::>> website.screenshot(name: "example")
+      :::>> website.navigate(name: "example")
+      session.execute_script "window.scrollBy(0,10)"
       ```
     RUBY
 


### PR DESCRIPTION
Supporting `pre.erb` means that any lookups need to happen at the last possible moment. Websites have a name lookup feature similar to background tasks. Background tasks adopted a lazy lookup model in `4.1.2`.

Ensuring these are all covered under test:

- `website.screenshot` is covered:

```
  1) Error:
SystemsCliTest#test_screenshots_dir:
  2) Error:
IntegrationWebsiteTest#test_screenshot_command:
```

- `website.visit` is covered

```
  1) Error:
SystemsCliTest#test_screenshots_dir:
  2) Error:
IntegrationWebsiteTest#test_screenshot_command:
```

- `website.navigate` is not covered. Adding a call to the integration test so it's at last exercised