### PR TITLE
Retry on ReadTimeout from website.visit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Fix: Net::ReadTimeout errors on `website.visit` are now retried by default (https://github.com/zombocom/rundoc/pull/103)
+
 ## 4.1.3
 
 - Fix: Internal error in `background.wait` introduced in 4.1.2 (https://github.com/zombocom/rundoc/pull/97)

--- a/lib/rundoc/code_command/website/driver.rb
+++ b/lib/rundoc/code_command/website/driver.rb
@@ -6,7 +6,7 @@ class Rundoc::CodeCommand::Website
   class Driver
     attr_reader :session
 
-    def initialize(name:, url:, width: 1024, height: 720, visible: false, io: $stdout)
+    def initialize(name:, url:, width: 1024, height: 720, visible: false, io: $stdout, read_timeout: 60)
       @io = io
       browser_options = ::Selenium::WebDriver::Chrome::Options.new
       browser_options.args << "--headless" unless visible
@@ -16,7 +16,10 @@ class Rundoc::CodeCommand::Website
       @width = width
       @height = height
 
-      @driver = Capybara::Selenium::Driver.new(nil, browser: :chrome, options: browser_options)
+      client = Selenium::WebDriver::Remote::Http::Default.new
+      client.read_timeout = read_timeout
+
+      @driver = Capybara::Selenium::Driver.new(nil, browser: :chrome, options: browser_options, http_client: client)
       driver_name = :"rundoc_driver_#{name}"
       Capybara.register_driver(driver_name) do |app|
         @driver

--- a/lib/rundoc/code_command/website/driver.rb
+++ b/lib/rundoc/code_command/website/driver.rb
@@ -6,7 +6,8 @@ class Rundoc::CodeCommand::Website
   class Driver
     attr_reader :session
 
-    def initialize(name:, url:, width: 1024, height: 720, visible: false)
+    def initialize(name:, url:, width: 1024, height: 720, visible: false, io: $stdout)
+      @io = io
       browser_options = ::Selenium::WebDriver::Chrome::Options.new
       browser_options.args << "--headless" unless visible
       browser_options.args << "--disable-gpu" if Gem.win_platform?
@@ -54,7 +55,7 @@ class Rundoc::CodeCommand::Website
       msg = +""
       msg << "Error running code #{code.inspect} at #{current_url.inspect}\n"
       msg << "saving a screenshot to: `tmp/error.png`"
-      puts msg
+      @io.puts msg
       error_path = env[:context].screenshots_dir.join("error.png")
       session.save_screenshot(error_path)
       raise e
@@ -66,13 +67,13 @@ class Rundoc::CodeCommand::Website
       file_name = self.class.next_screenshot_name
       file_path = screenshots_dir.join(file_name)
       session.save_screenshot(file_path)
-      puts "Screenshot saved to #{file_path}"
+      @io.puts "Screenshot saved to #{file_path}"
 
       return file_path unless upload
 
       case upload
       when "s3", "aws"
-        puts "Uploading screenshot to S3"
+        @io.puts "Uploading screenshot to S3"
         require "aws-sdk-s3"
         ENV.fetch("AWS_ACCESS_KEY_ID")
         s3 = Aws::S3::Resource.new(region: ENV.fetch("AWS_REGION"))

--- a/lib/rundoc/code_command/website/driver.rb
+++ b/lib/rundoc/code_command/website/driver.rb
@@ -28,8 +28,20 @@ class Rundoc::CodeCommand::Website
       @session = Capybara::Session.new(driver_name)
     end
 
-    def visit(url)
-      @session.visit(url)
+    def visit(url, max_attempts: 3, delay: 1)
+      attempts = 0
+      begin
+        @session.visit(url)
+      rescue ::Net::ReadTimeout => e
+        attempts += 1
+        if attempts > max_attempts
+          raise e
+        else
+          @io.puts "Error visiting url (#{attempts}/#{max_attempts}) `#{url}`:\n#{e}"
+          sleep delay
+          retry
+        end
+      end
     end
 
     def timestamp

--- a/lib/rundoc/code_command/website/visit.rb
+++ b/lib/rundoc/code_command/website/visit.rb
@@ -2,13 +2,14 @@
 
 class Rundoc::CodeCommand::Website
   class Visit < Rundoc::CodeCommand
-    def initialize(name:, url: nil, scroll: nil, height: 720, width: 1024, visible: false)
+    def initialize(name:, url: nil, scroll: nil, height: 720, width: 1024, visible: false, max_attempts: 3)
       @name = name
       @url = url
       @scroll = scroll
       @height = height
       @width = width
       @visible = visible
+      @max_attempts = max_attempts
     end
 
     def driver
@@ -33,7 +34,7 @@ class Rundoc::CodeCommand::Website
 
       puts message
 
-      driver.visit(@url) if @url
+      driver.visit(@url, max_attempts: @max_attempts) if @url
       driver.scroll(@scroll) if @scroll
 
       return "" if contents.nil? || contents.empty?

--- a/test/integration/website_test.rb
+++ b/test/integration/website_test.rb
@@ -50,7 +50,7 @@ class IntegrationWebsiteTest < Minitest::Test
     end
   end
 
-  def assert_logs_include(logs: , include_str: )
+  def assert_logs_include(logs:, include_str:)
     assert logs.include?(include_str), "Expected logs to include #{include_str} but they didnt. Logs:\n#{logs}"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -86,19 +86,17 @@ class Minitest::Test
 
   # Yields port, exits unexpectedly
   def tcp_unexpected_exit(timeout: 30)
-    Timeout::timeout(timeout) do
+    Timeout.timeout(timeout) do
       threads = []
-      server = TCPServer.new('127.0.0.1', 0)
+      server = TCPServer.new("127.0.0.1", 0)
       port = server.addr[1]
       threads << Thread.new do
-        begin
-          # Accept one connection, then raise an error to simulate unexpected close
-          client = server.accept
-          raise "Unexpected server error!"
-        rescue => e
-          # Simulate crash, but let ensure run
-        end
-      end.tap {|t| t.abort_on_exception = false }
+        # Accept one connection, then raise an error to simulate unexpected close
+        server.accept
+        raise "Unexpected server error!"
+      rescue
+        # Simulate crash, but let ensure run
+      end.tap { |t| t.abort_on_exception = false }
 
       threads << Thread.new do
         yield port

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,8 @@ require "rundoc"
 require "minitest/autorun"
 require "mocha/minitest"
 require "tmpdir"
+require "socket"
+require "timeout"
 
 class Minitest::Test
   SUCCESS_DIRNAME = Rundoc::CLI::DEFAULTS::ON_SUCCESS_DIR
@@ -80,5 +82,33 @@ class Minitest::Test
     end
 
     attr_reader :value
+  end
+
+  # Yields port, exits unexpectedly
+  def tcp_unexpected_exit(timeout: 30)
+    Timeout::timeout(timeout) do
+      threads = []
+      server = TCPServer.new('127.0.0.1', 0)
+      port = server.addr[1]
+      threads << Thread.new do
+        begin
+          # Accept one connection, then raise an error to simulate unexpected close
+          client = server.accept
+          raise "Unexpected server error!"
+        rescue => e
+          # Simulate crash, but let ensure run
+        end
+      end.tap {|t| t.abort_on_exception = false }
+
+      threads << Thread.new do
+        yield port
+      end
+
+      while threads.all?(&:alive?)
+        sleep 0.1
+      end
+    ensure
+      server.close if server && !server.closed?
+    end
   end
 end


### PR DESCRIPTION
From a rundoc failure in https://github.com/heroku/buildpacks/actions/runs/15529896322/job/43716418062#step:6:569:

```
Spawning commmand: `/usr/bin/env bash -c docker\ run\ --rm\ --env\ PORT\=5006\ -p\ 5006:5006\ my-image-name >> /tmp/log20250609-2361-qammwo 2>&1`
Running: $ '(sleep 10) 2>&1'
Visting: http://localhost:5006
Received exception: #<Net::ReadTimeout: Net::ReadTimeout>, cleaning up before re-raise
```

When a server closes unexpectedly, the Net::HTTP reader that Capybara uses by default will raise a `Net::ReadTimeout` error after waiting up to 60 seconds to receive a TCP "FIN" packet. I'm unsure of the conditions that cause this situation, but this commit adds the infrastructure needed to retry and test those retries. If it's intermittent, retrying will fix it. If it's not, at worst, we're adding some extra time to the execution, and it will continue to fail.