### PR TITLE
Schneems/print background process on abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Added: When a background process (`background.start`) does not exit cleanly, print its logs for help with debugging. (https://github.com/zombocom/rundoc/pull/104)
+
 ## 4.1.3
 
 - Fix: Internal error in `background.wait` introduced in 4.1.2 (https://github.com/zombocom/rundoc/pull/97)

--- a/lib/rundoc/cli.rb
+++ b/lib/rundoc/cli.rb
@@ -177,7 +177,7 @@ module Rundoc
         next unless task.alive?
 
         io.puts "Warning background task is still running, cleaning up: name: #{name}"
-        task.stop
+        task.stop(print_io: io)
       end
 
       if execution_context.output_dir.exist?

--- a/lib/rundoc/cli.rb
+++ b/lib/rundoc/cli.rb
@@ -176,7 +176,7 @@ module Rundoc
       Rundoc::CodeCommand::Background::ProcessSpawn.tasks.each do |name, task|
         next unless task.alive?
 
-        io.puts "Warning background task is still running, cleaning up: name: #{name}"
+        io.puts "Warning background task is still running, cleaning up: `#{name}`"
         task.stop(print_io: io)
       end
 

--- a/lib/rundoc/code_command/background/process_spawn.rb
+++ b/lib/rundoc/code_command/background/process_spawn.rb
@@ -45,7 +45,7 @@ class Rundoc::CodeCommand::Background
     attr_reader :log, :pid, :command
 
     def initialize(command, timeout: 5, log: Tempfile.new("log"), out: "2>&1")
-      @command = command
+      @original_command = command
       @timeout_value = timeout
       @log_reference = log # https://twitter.com/schneems/status/1285289971083907075
 
@@ -54,7 +54,7 @@ class Rundoc::CodeCommand::Background
       FileUtils.touch(@log)
       @pipe_output, @pipe_input = IO.pipe
 
-      @command = "/usr/bin/env bash -c #{@command.shellescape} >> #{@log} #{out}"
+      @command = "/usr/bin/env bash -c #{@original_command.shellescape} >> #{@log} #{out}"
       @pid = nil
     end
 

--- a/lib/rundoc/code_command/background/process_spawn.rb
+++ b/lib/rundoc/code_command/background/process_spawn.rb
@@ -125,7 +125,6 @@ class Rundoc::CodeCommand::Background
       @pipe_input.close
       Process.kill("TERM", -Process.getpgid(@pid))
       Process.wait(@pid)
-
     rescue Errno::ESRCH => e
       puts "Error stopping process (command: #{command}): #{e}"
     ensure

--- a/lib/rundoc/code_command/background/process_spawn.rb
+++ b/lib/rundoc/code_command/background/process_spawn.rb
@@ -120,13 +120,16 @@ class Rundoc::CodeCommand::Background
       contents
     end
 
-    def stop
+    def stop(print_io: nil)
       return unless alive?
       @pipe_input.close
       Process.kill("TERM", -Process.getpgid(@pid))
       Process.wait(@pid)
+
     rescue Errno::ESRCH => e
       puts "Error stopping process (command: #{command}): #{e}"
+    ensure
+      print_io&.puts "Log contents for `#{command}`:\n#{@log.read}"
     end
 
     def check_alive!

--- a/lib/rundoc/code_command/background/process_spawn.rb
+++ b/lib/rundoc/code_command/background/process_spawn.rb
@@ -47,7 +47,7 @@ class Rundoc::CodeCommand::Background
     def initialize(command, timeout: 5, log: Tempfile.new("log"), out: "2>&1")
       @original_command = command
       @timeout_value = timeout
-      @log_reference = log # https://twitter.com/schneems/status/1285289971083907075
+      @log_reference = log # Need to keep a reference to `Tempfile` or it will be deleted. Pathname does not retain the passed in reference
 
       @log = Pathname.new(log)
       @log.dirname.mkpath

--- a/test/integration/background_stdin_test.rb
+++ b/test/integration/background_stdin_test.rb
@@ -41,6 +41,43 @@ class BackgroundStdinTest < Minitest::Test
     end
   end
 
+  def test_print_output_on_exit
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+        script = dir.join("script.rb")
+        script.write loop_script
+
+        source_path = dir.join("RUNDOC.md")
+        source_path.write <<~EOF
+          ```
+          :::-- background.start("ruby #{script}",
+            name: "background_ungraceful_exit",
+            wait: ">",
+            timeout: 15
+          )
+          :::-- background.stdin_write("hello", name: "background_ungraceful_exit", wait: "hello")
+          ```
+        EOF
+
+        io = StringIO.new
+        Rundoc::CLI.new(
+          io: io,
+          source_path: source_path,
+          on_success_dir: dir.join(SUCCESS_DIRNAME)
+        ).call
+
+        assert_include(actual: io.string, include_str: "Warning background task is still running, cleaning up: name: script")
+        assert_include(actual: io.string, include_str: "Log contents for `/usr/bin/env bash -c")
+        assert_include(actual: io.string, include_str: "You said: hello")
+      end
+    end
+  end
+
+  def assert_include(actual: , include_str:)
+    assert actual.include?(include_str), "Expected to find `#{include_str}` in output, but did not. Output:\n#{actual}"
+  end
+
   def loop_script
     <<~'EOF'
       $stdout.sync = true

--- a/test/integration/background_stdin_test.rb
+++ b/test/integration/background_stdin_test.rb
@@ -74,7 +74,7 @@ class BackgroundStdinTest < Minitest::Test
     end
   end
 
-  def assert_include(actual: , include_str:)
+  def assert_include(actual:, include_str:)
     assert actual.include?(include_str), "Expected to find `#{include_str}` in output, but did not. Output:\n#{actual}"
   end
 

--- a/test/integration/background_stdin_test.rb
+++ b/test/integration/background_stdin_test.rb
@@ -67,7 +67,7 @@ class BackgroundStdinTest < Minitest::Test
           on_success_dir: dir.join(SUCCESS_DIRNAME)
         ).call
 
-        assert_include(actual: io.string, include_str: "Warning background task is still running, cleaning up: name: script")
+        assert_include(actual: io.string, include_str: "Warning background task is still running, cleaning up: `background_ungraceful_exit`")
         assert_include(actual: io.string, include_str: "Log contents for `/usr/bin/env bash -c")
         assert_include(actual: io.string, include_str: "You said: hello")
       end

--- a/test/integration/background_stdin_test.rb
+++ b/test/integration/background_stdin_test.rb
@@ -6,21 +6,7 @@ class BackgroundStdinTest < Minitest::Test
       Dir.chdir(dir) do
         dir = Pathname(dir)
         script = dir.join("script.rb")
-        script.write <<~'EOF'
-          $stdout.sync = true
-
-          print "> "
-          while line = gets
-            puts line
-            if line.strip == "exit"
-              puts "Bye"
-              return
-            else
-              puts "You said: #{line}"
-            end
-            print "> "
-          end
-        EOF
+        script.write loop_script
 
         source_path = dir.join("RUNDOC.md")
         source_path.write <<~EOF
@@ -53,5 +39,23 @@ class BackgroundStdinTest < Minitest::Test
         assert readme.include?(expected)
       end
     end
+  end
+
+  def loop_script
+    <<~'EOF'
+      $stdout.sync = true
+
+      print "> "
+      while line = gets
+        puts line
+        if line.strip == "exit"
+          puts "Bye"
+          return
+        else
+          puts "You said: #{line}"
+        end
+        print "> "
+      end
+    EOF
   end
 end


### PR DESCRIPTION
When a background process does not exit cleanly, print its logs for help with debugging.