### PR TITLE
Fix race condition

### DIFF
--- a/test/rundoc/code_commands/background_test.rb
+++ b/test/rundoc/code_commands/background_test.rb
@@ -88,6 +88,8 @@ class BackgroundTest < Minitest::Test
 
         run!("echo 'bar' >> #{file}")
 
+        background_start.background.wait("bar")
+
         log_read = Rundoc::CodeCommand::Background::Log::Read.new(name: "tail")
         output = log_read.call
 


### PR DESCRIPTION
There's no explicit syncronization between the read and the background process therefore there's a race condition with how fast `tail` will see and emit the change to the file. This adds an explicit wait to prevent this error:

```
Taking screenshot: https://example.com/
Screenshot saved to /tmp/d20250609-2250-ldid1l/screenshots/screenshot_1.png
website.navigate [example]: session.execute_script "window.scrollBy(0,10)"
..Spawning commmand: `/usr/bin/env bash -c tail\ -f\ foo.txt >> /tmp/log20250609-2250-odtb0q 2>&1`
.Spawning commmand: `/usr/bin/env bash -c cat >> /tmp/log20250609-2250-9binvx 2>&1`
.Spawning commmand: `/usr/bin/env bash -c tail\ -f\ foo.txt >> /tmp/log20250609-2250-1fcky7 2>&1`
F.....Writing to: 'foo/code.rb'
Writing to: 'foo/newb.rb'
Running: $ '(cat foo/newb.rb) 2>&1'
    puts 'hello world'
.Running: $ '(mkdir foo) 2>&1'
Running: $ '(ls) 2>&1'
    foo
........Spawning commmand: `/usr/bin/env bash -c ruby\ /tmp/d20250609-2250-r2bfe2/script.rb >> /tmp/log20250609-2250-8bf01k 2>&1`
.Deleting 'gem 'sqlite3'' from foo.rb
.

Finished in 11.287629s, 7.7961 runs/s, 22.5025 assertions/s.

  1) Failure:
BackgroundTest#test_background_start [test/rundoc/code_commands/background_test.rb:94]:
Expected: "bar"
  Actual: ""

88 runs, 254 assertions, 1 failures, 0 errors, 0 skips
Coverage report generated for Integration Tests to /home/runner/work/rundoc/rundoc/coverage.
Line Coverage: 95.91% (2042 / 2129)
rake aborted!
Command failed with status (1)
/home/runner/work/rundoc/rundoc/vendor/bundle/ruby/3.3.0/gems/rake-13.3.0/exe/rake:27:in `<top (required)>'
/opt/hostedtoolcache/Ruby/3.3.8/x64/bin/bundle:25:in `load'
/opt/hostedtoolcache/Ruby/3.3.8/x64/bin/bundle:25:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```